### PR TITLE
[FEAT] 질문 조회 및 답변 저장 API 구현

### DIFF
--- a/src/main/java/com/likelion/backend/config/SecurityConfig.java
+++ b/src/main/java/com/likelion/backend/config/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable) // http basic auth 기반 로그인 인증창 뜨지 않게
                 .formLogin(AbstractHttpConfigurer::disable) // 기본 로그인 페이지 뜨지 않게.
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/login","/my/{id}").permitAll() // 모두 허용
+                        .requestMatchers("join", "/login","/my/{id}", "question").permitAll() // 모두 허용
                         .anyRequest().authenticated())
                 .build();
     }

--- a/src/main/java/com/likelion/backend/controller/JoinController.java
+++ b/src/main/java/com/likelion/backend/controller/JoinController.java
@@ -1,7 +1,9 @@
 package com.likelion.backend.controller;
 
 import com.likelion.backend.dto.request.JoinRequestDto;
+import com.likelion.backend.dto.request.LoginRequestDto;
 import com.likelion.backend.dto.response.JoinResponseDto;
+import com.likelion.backend.dto.response.LoginResponseDto;
 import com.likelion.backend.dto.response.MyResponseDto;
 import com.likelion.backend.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -15,10 +17,15 @@ public class JoinController {
     private final MemberService memberService;
 
     @PostMapping("/login")
-    public ResponseEntity<?> login(@RequestBody JoinRequestDto joinRequestDto){
+    public ResponseEntity<LoginResponseDto> login(@RequestBody LoginRequestDto dto) {
+        return ResponseEntity.ok(memberService.login(dto));
+    }
+
+    @PostMapping("/join")
+    public ResponseEntity<?> join(@RequestBody JoinRequestDto joinRequestDto){
         try{
-            memberService.login(joinRequestDto);
-            return ResponseEntity.ok(memberService.login(joinRequestDto));
+            JoinResponseDto response = memberService.join(joinRequestDto);
+            return ResponseEntity.ok(response);
         } catch (Exception e){
             return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
         }

--- a/src/main/java/com/likelion/backend/controller/QuestionController.java
+++ b/src/main/java/com/likelion/backend/controller/QuestionController.java
@@ -1,0 +1,24 @@
+package com.likelion.backend.controller;
+
+import com.likelion.backend.domain.Question;
+import com.likelion.backend.dto.response.QuestionResponseDto;
+import com.likelion.backend.service.QuestionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/question")
+public class QuestionController {
+    private final QuestionService questionService;
+
+    @GetMapping()
+    public ResponseEntity<List<QuestionResponseDto>> getAllQuestions() {
+        return ResponseEntity.ok(questionService.getQuestion());
+    }
+}

--- a/src/main/java/com/likelion/backend/domain/Member.java
+++ b/src/main/java/com/likelion/backend/domain/Member.java
@@ -22,6 +22,8 @@ public class Member extends BaseTimeEntity{
     @Enumerated(EnumType.STRING)
     private Role role;
 
+    private String answer;
+
     // 생성자
     @Builder
     public Member(String name, String password, Role role) {
@@ -32,4 +34,8 @@ public class Member extends BaseTimeEntity{
 
     public boolean isBaby(){return Role.BABY.equals(this.role);}
     public boolean isAdult(){return Role.ADULT.equals(this.role);}
+
+    public void setAnswer(String answer) {
+        this.answer = answer;
+    }
 }

--- a/src/main/java/com/likelion/backend/domain/Question.java
+++ b/src/main/java/com/likelion/backend/domain/Question.java
@@ -1,0 +1,21 @@
+package com.likelion.backend.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Question extends BaseTimeEntity{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String content;
+
+}

--- a/src/main/java/com/likelion/backend/domain/QuestionResult.java
+++ b/src/main/java/com/likelion/backend/domain/QuestionResult.java
@@ -1,0 +1,28 @@
+package com.likelion.backend.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class QuestionResult {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne
+    @JoinColumn(name = "question_id")
+    private Question question;
+
+    private String answer;
+}

--- a/src/main/java/com/likelion/backend/dto/request/JoinRequestDto.java
+++ b/src/main/java/com/likelion/backend/dto/request/JoinRequestDto.java
@@ -4,10 +4,13 @@ import com.likelion.backend.domain.Member;
 import lombok.Getter;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
+import java.util.Map;
+
 @Getter
 public class JoinRequestDto {
     private String name;
     private String password;
+    private Map<String, String> answers;
 
     // 회원가입
     public Member toEntity(BCryptPasswordEncoder bCryptPasswordEncoder){

--- a/src/main/java/com/likelion/backend/dto/request/LoginRequestDto.java
+++ b/src/main/java/com/likelion/backend/dto/request/LoginRequestDto.java
@@ -1,0 +1,9 @@
+package com.likelion.backend.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class LoginRequestDto {
+    private String name;
+    private String password;
+}

--- a/src/main/java/com/likelion/backend/dto/response/JoinResponseDto.java
+++ b/src/main/java/com/likelion/backend/dto/response/JoinResponseDto.java
@@ -12,6 +12,7 @@ public class JoinResponseDto {
     private Long id;
     private String name;
     private Role role;
+    private String answer;
 
     // DTO 변환
     public static JoinResponseDto fromEntity(Member member){
@@ -22,6 +23,7 @@ public class JoinResponseDto {
                 .id(member.getId())
                 .name(member.getName())
                 .role(member.getRole())
+                .answer(member.getAnswer())
                 .build();
     }
 }

--- a/src/main/java/com/likelion/backend/dto/response/LoginResponseDto.java
+++ b/src/main/java/com/likelion/backend/dto/response/LoginResponseDto.java
@@ -1,0 +1,14 @@
+package com.likelion.backend.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginResponseDto {
+    // private String accessToken;
+    private Long memberId;
+    private String name;
+    private String role;
+    private boolean hasQuestionResult;
+}

--- a/src/main/java/com/likelion/backend/dto/response/QuestionResponseDto.java
+++ b/src/main/java/com/likelion/backend/dto/response/QuestionResponseDto.java
@@ -1,0 +1,22 @@
+package com.likelion.backend.dto.response;
+
+import com.likelion.backend.domain.Question;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class QuestionResponseDto {
+
+    private Long questionId;
+    private String content;
+
+    public static QuestionResponseDto fromEntity(Question question) {
+        return QuestionResponseDto.builder()
+                .questionId(question.getId())
+                .content(question.getContent())
+                .build();
+    }
+}

--- a/src/main/java/com/likelion/backend/repository/QuestionRepository.java
+++ b/src/main/java/com/likelion/backend/repository/QuestionRepository.java
@@ -1,0 +1,7 @@
+package com.likelion.backend.repository;
+
+import com.likelion.backend.domain.Question;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+}

--- a/src/main/java/com/likelion/backend/repository/QuestionResultRepository.java
+++ b/src/main/java/com/likelion/backend/repository/QuestionResultRepository.java
@@ -1,0 +1,10 @@
+package com.likelion.backend.repository;
+
+import com.likelion.backend.domain.Member;
+import com.likelion.backend.domain.QuestionResult;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuestionResultRepository extends JpaRepository<QuestionResult, Long> {
+
+    boolean existsByMember(Member member);
+}

--- a/src/main/java/com/likelion/backend/service/MemberService.java
+++ b/src/main/java/com/likelion/backend/service/MemberService.java
@@ -1,41 +1,127 @@
 package com.likelion.backend.service;
 
 import com.likelion.backend.domain.Member;
+import com.likelion.backend.domain.Question;
+import com.likelion.backend.domain.QuestionResult;
 import com.likelion.backend.dto.request.JoinRequestDto;
+import com.likelion.backend.dto.request.LoginRequestDto;
 import com.likelion.backend.dto.response.JoinResponseDto;
+import com.likelion.backend.dto.response.LoginResponseDto;
 import com.likelion.backend.dto.response.MyResponseDto;
 import com.likelion.backend.repository.MemberRepository;
+import com.likelion.backend.repository.QuestionRepository;
+import com.likelion.backend.repository.QuestionResultRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final QuestionRepository questionRepository;
+    private final QuestionResultRepository questionResultRepository;
+
     // 비밀번호 인코더 DI (생성자 주입)
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
-    public JoinResponseDto login(JoinRequestDto joinRequestDto) {
-        // 해당 name이 이미 존재시
-        if (memberRepository.existsByName(joinRequestDto.getName())){
-            Member member = memberRepository.findByName(joinRequestDto.getName())
-                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
-            // 비번 검사
-            if (!bCryptPasswordEncoder.matches(joinRequestDto.getPassword(),member.getPassword())){
-                throw new IllegalArgumentException("비밀번호가 올바르지 않습니다.");
-            }
-            return JoinResponseDto.fromEntity(member);
+    public LoginResponseDto login(LoginRequestDto dto) {
+
+        // 1) 사용자 조회
+        Member member = memberRepository.findByName(dto.getName())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+        // 2) 비밀번호 검증
+        if (!bCryptPasswordEncoder.matches(dto.getPassword(), member.getPassword())) {
+            throw new IllegalArgumentException("비밀번호가 틀렸습니다.");
         }
 
-        // 유저 객체 생성
-        Member member = joinRequestDto.toEntity(bCryptPasswordEncoder);
+        // 질문 응답 여부
+        boolean hasQuestion = questionResultRepository.existsByMember(member);
 
+        return new LoginResponseDto(
+                member.getId(),
+                member.getName(),
+                member.getRole().name(),
+                hasQuestion
+        );
+    }
+
+    public JoinResponseDto join(JoinRequestDto dto){
+
+        // 1. 이미 존재하는 사용자면 예외 던짐 (회원가입이므로)
+        if (memberRepository.existsByName(dto.getName())) {
+            throw new IllegalArgumentException("이미 존재하는 사용자입니다.");
+        }
+
+        // 2. 신규 회원 생성
+        Member member = dto.toEntity(bCryptPasswordEncoder);
         memberRepository.save(member);
 
+        // 3. 질문 답변 저장 + 캐릭터 판정 준비
+        Map<String, String> answers = dto.getAnswers();
+
+        String resultType = null;
+        boolean determined = false;
+
+        String s1 = answers.get("1");
+        if (s1 != null) {
+            try {
+                int v1 = Integer.parseInt(s1.trim());
+                if (v1 >= 8) {
+                    resultType = "팔로워형 사자";
+                    determined = true;
+                }
+            } catch (NumberFormatException ignored) {}
+        }
+
+
+        if (!determined) {
+            String s2 = answers.get("2");
+            if (s2 != null) {
+                try {
+                    int v2 = Integer.parseInt(s2.trim());
+                    if (v2 >= 8) {
+                        resultType = "헤롱헤롱 사자";
+                        determined = true;
+                    }
+                } catch (NumberFormatException ignored) {}
+            }
+        }
+
+        if (!determined && answers.containsKey("5") && answers.containsKey("3")) {
+            String v5 = answers.get("5") == null ? "" : answers.get("5").trim();
+            String v3 = answers.get("3") == null ? "" : answers.get("3").trim();
+
+            if (v3.length() > 0) {
+                char first = Character.toUpperCase(v3.charAt(0));
+                if ("밖순이".equals(v5) && first == 'E') {
+                    resultType = "식빵 굽는 사자";
+                    determined = true;
+                } else if ("밖순이".equals(v5) && first == 'I') {
+                    resultType = "친구를 만나느라 샤샤샤자";
+                    determined = true;
+                } else if ("집순이".equals(v5) && first == 'E') {
+                    resultType = "반전 매력 사자";
+                    determined = true;
+                } else if ("집순이".equals(v5) && first == 'I') {
+                    resultType = "이불 속 사자";
+                    determined = true;
+                }
+            }
+        }
+
+        // 4. Member 의 answer 필드에 저장
+        member.setAnswer(resultType);
+        memberRepository.save(member);
+
+        // 5. 응답 반환
         return JoinResponseDto.fromEntity(member);
     }
+
 
     public MyResponseDto my(Long id){
 

--- a/src/main/java/com/likelion/backend/service/QuestionService.java
+++ b/src/main/java/com/likelion/backend/service/QuestionService.java
@@ -1,0 +1,21 @@
+package com.likelion.backend.service;
+
+import com.likelion.backend.dto.response.QuestionResponseDto;
+import com.likelion.backend.repository.QuestionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class QuestionService {
+
+    private final QuestionRepository questionRepository;
+
+    public List<QuestionResponseDto> getQuestion(){
+        return questionRepository.findAll().stream()
+                .map(QuestionResponseDto::fromEntity)
+                .toList();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   config:
     import: optional:application-secret.yml
   profiles:
-    active: local
+    active: development
   jpa:
     hibernate:
       ddl-auto: create


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #4

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)
- 질문 조회 api 구현
- 유저 로그인 기능 및 회원가입 수정
- 유저 회원가입 시 결과 받아올 수 있게 로직 구현

---

## ✅ 변경 사항 체크리스트

다음 항목들을 확인하고 체크해주세요.

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** (예: 로컬, 개발 서버 등)
* **테스트 방법:** (예: Postman, 단위 테스트, 수동 기능 테스트 등)
* **결과 요약:** (예: 모든 테스트 통과, 새로운 테스트 케이스 3개 추가 완료)

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.
<img width="1608" height="1228" alt="image" src="https://github.com/user-attachments/assets/8e8f768d-9db6-4dd2-8a86-8215c3519e80" />
<img width="950" height="302" alt="image" src="https://github.com/user-attachments/assets/9d77496c-e502-488b-9ed3-2132aed46558" />



---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

**로직수정**
맨 처음 로그인(api: /login)
→ (200ok) 결과화면(api: /my) 받아오면 됨
    → (없으면) 질문 받아와서(api: /question (get)) 띄워주는 화면
    → 결과 받으면 회원가입 (api: /join)동작 (api 보낼 때 안에다가 질문 결과 넣으면 됨)
        → 결과화면 띄워주기 (join 보낼 때 받은걸로 하던 my로 하던 마음대로.)

**급한거**
- 마이페이지(/my) 조회할 때 결과값(~~사자) member에 answer에 있는거도 가져와서 띄우게 하기
- 질문 리스트 보낼 때 지금 제목만 받고 보기 보여줘야 하는것들 항목을 못보여주고 있는데 이거 보여주기 → 질문리스트는 노션에 백앤드 페이지 데이터베이스 스키마에 있음.
---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.