### PR TITLE
[feat] 질문 조회 업뎃, /my 조회 업뎃

### DIFF
--- a/src/main/java/com/likelion/backend/controller/QuestionController.java
+++ b/src/main/java/com/likelion/backend/controller/QuestionController.java
@@ -1,13 +1,12 @@
 package com.likelion.backend.controller;
 
 import com.likelion.backend.domain.Question;
+import com.likelion.backend.dto.request.QuestionRequestDto;
 import com.likelion.backend.dto.response.QuestionResponseDto;
 import com.likelion.backend.service.QuestionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -16,6 +15,11 @@ import java.util.List;
 @RequestMapping("/question")
 public class QuestionController {
     private final QuestionService questionService;
+
+    @PostMapping
+    public ResponseEntity<QuestionResponseDto> postQuestion(@RequestBody QuestionRequestDto questionRequestDto){
+        return ResponseEntity.ok(questionService.postQuestion(questionRequestDto));
+    }
 
     @GetMapping()
     public ResponseEntity<List<QuestionResponseDto>> getAllQuestions() {

--- a/src/main/java/com/likelion/backend/domain/Question.java
+++ b/src/main/java/com/likelion/backend/domain/Question.java
@@ -1,11 +1,13 @@
 package com.likelion.backend.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import com.likelion.backend.enums.QuestionType;
+import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -16,6 +18,21 @@ public class Question extends BaseTimeEntity{
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String content;
+    private String content; // 질문 이름
+
+    private QuestionType type; // 질문 유형 (척도, 주관식입력, 선택형)
+
+    @ElementCollection
+    @CollectionTable(name = "question_choices", joinColumns = @JoinColumn(name = "question_id"))
+    @Column(name = "choice")
+    private List<String> choices; // 선택형 질문 보기들.
+
+    // 생성자
+    @Builder
+    public Question(String content, QuestionType type, List<String> choices){
+        this.content = content;
+        this.type = type;
+        this.choices = new ArrayList<>(choices);
+    }
 
 }

--- a/src/main/java/com/likelion/backend/dto/request/QuestionRequestDto.java
+++ b/src/main/java/com/likelion/backend/dto/request/QuestionRequestDto.java
@@ -1,0 +1,37 @@
+package com.likelion.backend.dto.request;
+
+import com.likelion.backend.domain.Question;
+import com.likelion.backend.enums.QuestionType;
+import jakarta.persistence.ElementCollection;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class QuestionRequestDto {
+    private String content; // 질문 제목
+    private String inputType; // 클라리언특 보내는 값
+    private QuestionType type;
+    private List<String> choices;
+
+    public QuestionType toQuestionType() {
+        return switch (inputType.toUpperCase()) {
+            case "METRIC" -> QuestionType.METRIC;
+            case "STRING" -> QuestionType.STRING;
+            case "CHOICES" -> QuestionType.CHOICES;
+            default -> throw new IllegalArgumentException("잘못된 InputType입니다.");
+        };
+    }
+
+    public Question toEntity() {
+        return Question.builder()
+                .content(this.content)
+                .type(toQuestionType())
+                .choices(this.choices)
+                .build();
+    }
+}

--- a/src/main/java/com/likelion/backend/dto/response/MyResponseDto.java
+++ b/src/main/java/com/likelion/backend/dto/response/MyResponseDto.java
@@ -13,6 +13,7 @@ public class MyResponseDto {
     private Long id;
     private String name;
     private Role role;
+    private String answer;
     // 질문 관련 내용 private List ..
     // 이미지 관련 내용
 
@@ -25,6 +26,7 @@ public class MyResponseDto {
                 .id(member.getId())
                 .name(member.getName())
                 .role(member.getRole())
+                .answer(member.getAnswer())
                 .build();
     }
 }

--- a/src/main/java/com/likelion/backend/dto/response/QuestionResponseDto.java
+++ b/src/main/java/com/likelion/backend/dto/response/QuestionResponseDto.java
@@ -1,22 +1,40 @@
 package com.likelion.backend.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.likelion.backend.domain.Question;
+import com.likelion.backend.enums.QuestionType;
+import jakarta.persistence.ElementCollection;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.List;
+
 @Getter
 @Builder
 @AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class QuestionResponseDto {
 
     private Long questionId;
     private String content;
+    //private QuestionType type;
+    private List<String> choices;
 
     public static QuestionResponseDto fromEntity(Question question) {
+        List<String> choicesToReturn = null;
+
+        if (question.getType() == QuestionType.CHOICES) {
+            choicesToReturn = question.getChoices();
+        }
+        else if(question.getType() == QuestionType.METRIC){
+            choicesToReturn = question.getChoices();
+        }
+
         return QuestionResponseDto.builder()
                 .questionId(question.getId())
                 .content(question.getContent())
+                .choices(choicesToReturn)
                 .build();
     }
 }

--- a/src/main/java/com/likelion/backend/enums/QuestionType.java
+++ b/src/main/java/com/likelion/backend/enums/QuestionType.java
@@ -1,0 +1,10 @@
+package com.likelion.backend.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum QuestionType {
+    METRIC, // 1~10 점의 척도
+    STRING, // 문장 단순 입력
+    CHOICES; // string형 문장 선택
+}

--- a/src/main/java/com/likelion/backend/service/QuestionService.java
+++ b/src/main/java/com/likelion/backend/service/QuestionService.java
@@ -1,5 +1,7 @@
 package com.likelion.backend.service;
 
+import com.likelion.backend.domain.Question;
+import com.likelion.backend.dto.request.QuestionRequestDto;
 import com.likelion.backend.dto.response.QuestionResponseDto;
 import com.likelion.backend.repository.QuestionRepository;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +14,13 @@ import java.util.List;
 public class QuestionService {
 
     private final QuestionRepository questionRepository;
+
+    public QuestionResponseDto postQuestion(QuestionRequestDto questionRequestDto){
+        // 질문 생성
+        Question question = questionRequestDto.toEntity();
+        questionRepository.save(question);
+        return QuestionResponseDto.fromEntity(question);
+    }
 
     public List<QuestionResponseDto> getQuestion(){
         return questionRepository.findAll().stream()


### PR DESCRIPTION


## #️⃣ 연관된 이슈
- 6

## ✨ 작업 내용 (Summary)
- /my 관련해서 MyResponseDto 에 answer 필드 추가
- GET /question 할 때 질문 제목 + 선택지 까지 보여주도록 수정
- POST /question API 생성 (개발진용)

## ✅ 변경 사항 체크리스트

다음 항목들을 확인하고 체크해주세요.
- Enums/QuestionType 생성 (METRICS, STRINGS, CHOICES)
- Question 엔티티 필드 추가
- QuestionRequestDto 생성 (POST용)
- QuestionResponseDto 수정 (choices 보여주는 거 관련해서 추가함)
---

## 🧪 테스트 결과
- 로컬 DB에서 실행

## 📸 스크린샷
<img width="700" height="880" alt="image" src="https://github.com/user-attachments/assets/8aa64928-2534-4605-b793-95e49601600f" />

<img width="1171" height="1227" alt="image" src="https://github.com/user-attachments/assets/ce26406d-fcf2-452d-ac0d-8bfec50abada" />
<img width="489" height="118" alt="image" src="https://github.com/user-attachments/assets/ab14668e-238b-4db8-9352-3d80fc00a46c" />


## 💬 리뷰 요구사항
