### PR TITLE
fix : Basetime 엔티티, 질문 생성시 keyword로 지정하게함. JpaConfiv 파일 추가

### DIFF
--- a/src/main/java/com/likelion/backend/config/JpaConfig.java
+++ b/src/main/java/com/likelion/backend/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.likelion.backend.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/main/java/com/likelion/backend/domain/BaseTimeEntity.java
+++ b/src/main/java/com/likelion/backend/domain/BaseTimeEntity.java
@@ -9,6 +9,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 @Getter
@@ -17,8 +18,8 @@ import java.time.LocalTime;
 public class BaseTimeEntity {
     @CreatedDate
     @Column(updatable = false)
-    private LocalTime createdAt;
+    private LocalDateTime createdAt;
 
     @LastModifiedDate
-    private LocalTime updatedAt;
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/likelion/backend/domain/Question.java
+++ b/src/main/java/com/likelion/backend/domain/Question.java
@@ -31,9 +31,10 @@ public class Question extends BaseTimeEntity{
 
     // 생성자
     @Builder
-    public Question(String content, QuestionType type, List<String> choices){
+    public Question(String content, QuestionType type, String keyword, List<String> choices){
         this.content = content;
         this.type = type;
+        this.keyword = keyword;
         this.choices = new ArrayList<>(choices);
         this.keyword = "";
     }

--- a/src/main/java/com/likelion/backend/dto/request/QuestionRequestDto.java
+++ b/src/main/java/com/likelion/backend/dto/request/QuestionRequestDto.java
@@ -16,6 +16,7 @@ public class QuestionRequestDto {
     private String content; // 질문 제목
     private String inputType; // 클라리언특 보내는 값
     private QuestionType type;
+    private String keyword; //질문 키워드
     private List<String> choices;
 
     public QuestionType toQuestionType() {
@@ -31,6 +32,7 @@ public class QuestionRequestDto {
         return Question.builder()
                 .content(this.content)
                 .type(toQuestionType())
+                .keyword(this.keyword)
                 .choices(this.choices)
                 .build();
     }


### PR DESCRIPTION

## #️⃣ 연관된 이슈

> 39
## ✨ 작업 내용 (Summary)

> Basetime 엔티티 속성 null로 저장되는거 -> 시간 ㄹㅇ 반영하게끔
> Question 등록할 때 keyword 값도 json body로 주게끔 추가

## ✅ 변경 사항 체크리스트

다음 항목들을 확인하고 체크해주세요.

- BaseTime 엔티티 속성 도메인 LocalTIme -> LocalDateTime으로 수정
- JpaConfiguation 클래스 파일 추가 -> 시간 업데이트/반영 설정 추가
- QuestionRequestDto, Question 빌더에 String keyword 속성 추가

